### PR TITLE
Informa mensagem de erro da API e Altera o placeholder do campo linkedin

### DIFF
--- a/components/Apoiador/index.jsx
+++ b/components/Apoiador/index.jsx
@@ -89,7 +89,11 @@ export const Apoiador = () => {
             resetForm();
           } catch (error) {
             openPopup();
-            setPopupMessage("Erro inesperado, tente novamente mais tarde");
+            {
+              error.response ?
+              setPopupMessage(error.response.data.message) :
+              setPopupMessage("Erro inesperado, tente novamente mais tarde");
+            }
           } finally {
             setLoading(false);
           }

--- a/components/Head/index.jsx
+++ b/components/Head/index.jsx
@@ -247,7 +247,7 @@ const handleClearInput = (setFieldValue, nameInput) => {
                       <Field
                         type="text"
                         name="linkedin"
-                        placeholder="https://www.linkedin.com/in/"
+                        placeholder="https://www.linkedin.com/in/usuario/"
                         className={styles.input}
                       />
                       <ErrorMessage
@@ -306,7 +306,7 @@ const handleClearInput = (setFieldValue, nameInput) => {
                         <Field
                           type="text"
                           name="indicationLinkedin"
-                          placeholder="https://www.linkedin.com/in/"
+                          placeholder="https://www.linkedin.com/in/usuario/"
                           className={styles.input}
                         />
                         <ErrorMessage

--- a/components/Head/index.jsx
+++ b/components/Head/index.jsx
@@ -118,7 +118,11 @@ export const Head = () => {
           resetForm();
         } catch (error) {
           openPopup();
-          setPopupMessage("Erro inesperado, tente novamente mais tarde");
+          {
+            error.response ?
+            setPopupMessage(error.response.data.message) :
+            setPopupMessage("Erro inesperado, tente novamente mais tarde");
+          }
         } finally {
           setLoading(false);
         }

--- a/components/Junior/index.jsx
+++ b/components/Junior/index.jsx
@@ -155,7 +155,11 @@ export const Junior = () => {
         resetForm();
       } catch (error) {
         openPopup();
-        setPopupMessage("Erro inesperado, tente novamente mais tarde");
+        {
+          error.response ?
+          setPopupMessage(error.response.data.message) :
+          setPopupMessage("Erro inesperado, tente novamente mais tarde");
+        }
       } finally {
         setLoading(false);
       }

--- a/components/Junior/index.jsx
+++ b/components/Junior/index.jsx
@@ -285,7 +285,7 @@ export const Junior = () => {
                       <Field
                         type="text"
                         name="linkedin"
-                        placeholder="https://www.linkedin.com/in/"
+                        placeholder="https://www.linkedin.com/in/usuario/"
                         className={styles.input}
                       />
                       <ErrorMessage
@@ -344,7 +344,7 @@ export const Junior = () => {
                         <Field
                           type="text"
                           name="indicationLinkedin"
-                          placeholder="https://www.linkedin.com/in/"
+                          placeholder="https://www.linkedin.com/in/usuario/"
                           className={styles.input}
                         />
                         <ErrorMessage

--- a/components/Mentor/index.jsx
+++ b/components/Mentor/index.jsx
@@ -155,7 +155,11 @@ export const Mentor = () => {
         resetForm();
       } catch (error) {
         openPopup();
-        setPopupMessage("Erro inesperado, tente novamente mais tarde");
+        {
+          error.response ?
+          setPopupMessage(error.response.data.message) :
+          setPopupMessage("Erro inesperado, tente novamente mais tarde");
+        }
       } finally {
         setLoading(false);
       }

--- a/components/Mentor/index.jsx
+++ b/components/Mentor/index.jsx
@@ -284,7 +284,7 @@ export const Mentor = () => {
                       <Field
                         type="text"
                         name="linkedin"
-                        placeholder="https://www.linkedin.com/in/"
+                        placeholder="https://www.linkedin.com/in/usuario/"
                         className={styles.input}
                       />
                       <ErrorMessage
@@ -342,7 +342,7 @@ export const Mentor = () => {
                           <Field
                             type="text"
                             name="indicationLinkedin"
-                            placeholder="https://www.linkedin.com/in/"
+                            placeholder="https://www.linkedin.com/in/usuario/"
                             className={styles.input}
                           />
                           <ErrorMessage


### PR DESCRIPTION
Informa ao usuario uma mensagem de erro da api ao submeter o formulário e altera o placeholder do campo linkedin para sugerir ao usuário a forma correta de preenchimento.

![1](https://github.com/user-attachments/assets/e0946460-b1d2-44a3-a13b-855a6009a113)
![2](https://github.com/user-attachments/assets/ef12364b-c430-4951-9217-6e19026d6859)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Melhorias**
  - Mensagens de erro dos formulários agora exibem detalhes específicos quando disponíveis, tornando o feedback mais claro para o usuário.
  - Atualização dos placeholders dos campos de LinkedIn para "https://www.linkedin.com/in/usuario/", facilitando o preenchimento correto dos dados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->